### PR TITLE
added insert method for efficient bulk insert of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ assert list(kv.items()) == [
 
 Set the `reverse` argument to True for the `keys()` and `items()` methods to sort in descending order.
 
+### Bulk inserting data
+
+The SQLite DB backend can be very slow when bulk inserting data. You can use the insert method to insert efficiently in bulk.
+
+```python
+kv.insert(((str(i), ':{}'.format(i)) for i in range(50000)))
+```
+
+The batch size is 1000 by default, you should modify it depending on the size of your data and available memory.
+
+```python
+kv.insert(((str(i), ':{}'.format(i)) for i in range(50000)), batch_size=40000)
+```
+
 
 ## Installing leveldb
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,3 +27,18 @@ def test_sanity():
 
     assert list(kv.keys(reverse=True)) == sorted(data.keys(), reverse=True)
     assert list(kv.items(reverse=True)) == sorted(data.items(), reverse=True)
+
+def test_insert():
+    from kvfile import KVFile
+    kv = KVFile()
+    kv.insert(((str(i), ':{}'.format(i)) for i in range(50000)))
+    assert len(list(kv.keys())) == 50000
+    assert len(list(kv.items())) == 50000
+    assert kv.get('49999') == ':49999'
+
+    kv.insert(((str(i), ':{}'.format(i)) for i in range(50000, 100000)), batch_size=40000)
+    assert len(list(kv.items())) == 100000
+
+    kv.insert(((str(i), ':{}'.format(i)) for i in range(100000, 100002)), batch_size=1)
+    kv.insert(((str(i), ':{}'.format(i)) for i in range(100002, 100005)), batch_size=0)
+    assert len(list(kv.items())) == 100005


### PR DESCRIPTION
currently the sqlite backend is extremely slow when bulk inserting data - making it almost unusable

added an `insert` method which bulk inserts data in configurable batch size (default size of 1000)

updated README and tests